### PR TITLE
Build: passage de Nixpacks à Docker (Composer install + ext-mongodb + .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+.env
+**/node_modules
+mongodb/user_logs.json
+mongodb/*.migrated_*
+phpinfo.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,35 @@
-# Dockerfile
+# 1) Base PHP 8.1 + Apache
 FROM php:8.1-apache
 
-# Installer extensions PHP
+# 2) Paquets utiles (git/unzip pour Composer, SSL pour PECL)
+RUN apt-get update && apt-get install -y \
+    git unzip libssl-dev pkg-config \
+ && rm -rf /var/lib/apt/lists/*
+
+# 3) Extensions PHP natives
 RUN docker-php-ext-install pdo pdo_mysql
 
-# Copier fichiers
-COPY . /var/www/html/
+# 4) Extension MongoDB (native) + activation
+RUN pecl install mongodb \
+ && docker-php-ext-enable mongodb
 
-# Configuration Apache
-RUN chown -R www-data:www-data /var/www/html
+# 5) Apache (réécritures si tu as des routes)
 RUN a2enmod rewrite
 
+# 6) Composer (depuis l'image officielle)
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# 7) Répertoire de travail
+WORKDIR /var/www/html
+
+# 8) Copier le code dans l'image
+COPY . .
+
+# 9) Installer dépendances PHP (prod)
+RUN composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader
+
+# 10) Droits (selon besoin)
+RUN chown -R www-data:www-data /var/www/html
+
+# 11) Port web
 EXPOSE 80

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "require": {
     "php": "^8.1",
+    "ext-mongodb": "*",
     "vlucas/phpdotenv": "^5.6",
     "mongodb/mongodb": "^2.1"
   }


### PR DESCRIPTION
Build: passage de Nixpacks à Docker

- Ajout d’un Dockerfile complet (PHP 8.1 + Apache + Composer)
- Installation de l’extension MongoDB via pecl
- composer install intégré dans l’image
- Ajout de .dockerignore (sécurité, image plus légère)
- Ajout "ext-mongodb" dans composer.json (contrainte de build)

Objectif : quitter le build automatique Nixpacks pour un build Docker contrôlé,
avec toutes les dépendances et extensions nécessaires.
